### PR TITLE
[Adjustment][Pauline] Remove Hardcoded False from Logger Middleware Configuration

### DIFF
--- a/logger/README.md
+++ b/logger/README.md
@@ -16,7 +16,7 @@ import { LoggerService, centralizedLoggerMiddleware } from '@symphco/logger';
 export class AppModule {
     async configure(consumer: MiddlewareConsumer) {
         consumer.apply(
-            await LoggerService.generateMiddleware(false),
+            await LoggerService.generateMiddleware(process.env.NODE_ENV !== 'development',),
             centralizedLoggerMiddleware
         ).forRoutes('*');
     }


### PR DESCRIPTION
## What does this PR do?
- Adjusts logger middleware configuration to respond to the NODE_ENV environment variable

## Why did you choose this solution?
- To make logger behavior environment-specific, with logging disabled in development

## What is the dependency graph of the changes?
- logger/README.md updated with configuration change

## How to test/verify?
- Set NODE_ENV to 'development' and confirm logging is disabled
- Unset NODE_ENV or set to non-'development' and confirm logging is enabled

## Related ticket url:
- 